### PR TITLE
keycode is deprecated, also === is better

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,19 +5,19 @@ document.addEventListener('contextmenu', event => event.preventDefault());
 // To disable F12 options
 document.onkeypress = function (event) {
   event = (event || window.event);
-  if (event.keyCode == 123) {
-    return false;
-  }
+   if (event.key === "F12" || event.keyCode === 123) {
+     return false;
+   }
 }
 document.onmousedown = function (event) {
   event = (event || window.event);
-  if (event.keyCode == 123) {
+  if (event.key === "F12" || event.keyCode === 123) {
     return false;
   }
 }
 document.onkeydown = function (event) {
   event = (event || window.event);
-  if (event.keyCode == 123) {
+  if (event.key === "F12" || event.keyCode === 123) {
     return false;
   }
 }
@@ -27,8 +27,8 @@ jQuery(document).ready(function ($) {
   $(document).keydown(function (event) {
     var pressedKey = String.fromCharCode(event.keyCode).toLowerCase();
 
-    if (event.ctrlKey && (pressedKey == "c" || pressedKey == "u")) {
-      alert('Sorry, This Functionality Has Been Disabled!');
+    if (event.ctrlKey && (pressedKey === "c" || pressedKey === "u")) {
+      alert("Sorry, This Functionality Has Been Disabled!");
       //disable key press porcessing
       return false;
     }


### PR DESCRIPTION
using event.key for key check but I keep keycode as compatibility.
=== is strong type check and faster because they don't convert type.
#hacktoberfest 