### PR TITLE
Improve FB sharing: add logs and fallback warning when `window.FB` is…

### DIFF
--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -149,8 +149,12 @@ const fbShareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComp
         const shareUrl = btn.dataset.shareUrl ?? btn.href;
         const fb = (window as WindowWithFb).FB;
         if (fb) {
-          fb.ui({ method: 'share', href: shareUrl }, () => {});
+          console.log('[share] using FB.ui', { shareUrl });
+          fb.ui({ method: 'share', href: shareUrl }, (response) => {
+            console.log('[share] FB.ui callback response:', response);
+          });
         } else {
+          console.warn('[share] window.FB not ready at click — falling back to sharer.php');
           warm();
           sharerFallback(btn.href);
         }


### PR DESCRIPTION
… unavailable